### PR TITLE
Feature/purify events

### DIFF
--- a/src/entity/Item.java
+++ b/src/entity/Item.java
@@ -2,6 +2,10 @@ package entity;
 
 import java.util.Set;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
 /**
  * This class defines the structure of an event item holding data fields that
  * are needed in the project
@@ -21,36 +25,94 @@ public class Item {
 	private String url;
 	private double distance;
 
+	/**
+	 * This method obtains the id of the event item
+	 * 
+	 * @return String The id of the event item
+	 */
 	public String getItemId() {
 		return itemId;
 	}
 
+	/**
+	 * This method obtains the name of the event item
+	 * 
+	 * @return String The name of the event item
+	 */
 	public String getName() {
 		return name;
 	}
 
+	/**
+	 * This method obtains the rating of the event item
+	 * 
+	 * @return double The rating of the event item
+	 */
 	public double getRating() {
 		return rating;
 	}
 
+	/**
+	 * This method obtains the address of the event item
+	 * 
+	 * @return String The address of the event item
+	 */
 	public String getAddress() {
 		return address;
 	}
 
+	/**
+	 * This method obtains the categories of the event item. Since the category may
+	 * not be only one, the method returns a set of category
+	 * 
+	 * @return Set<String> The categories of the event item
+	 */
 	public Set<String> getCategories() {
 		return categories;
 	}
 
+	/**
+	 * This method obtains the URL of the image of the event item
+	 * 
+	 * @return String The URL of the image of the event item
+	 */
 	public String getImageUrl() {
 		return imageUrl;
 	}
 
+	/**
+	 * This method obtains the URL of the event item
+	 * 
+	 * @return String The URL of the event item
+	 */
 	public String getUrl() {
 		return url;
 	}
 
+	/**
+	 * This method obtains the distance of the event item
+	 * 
+	 * @return double The distance of the event item
+	 */
 	public double getDistance() {
 		return distance;
+	}
+
+	public JSONObject toJSONObject() {
+		JSONObject obj = new JSONObject();
+		try {
+			obj.put("item_id", itemId);
+			obj.put("name", name);
+			obj.put("rating", rating);
+			obj.put("address", address);
+			obj.put("categories", new JSONArray(categories));
+			obj.put("image_url", imageUrl);
+			obj.put("url", url);
+			obj.put("distance", distance);
+		} catch (JSONException e) {
+			e.printStackTrace();
+		}
+		return obj;
 	}
 
 }

--- a/src/entity/Item.java
+++ b/src/entity/Item.java
@@ -98,9 +98,17 @@ public class Item {
 		return distance;
 	}
 
+	/**
+	 * This method converts the Item JAVA class to a JSON Object
+	 * 
+	 * @return JSONObject The event item in JSON Object format
+	 */
 	public JSONObject toJSONObject() {
+		// Create an empty JSON object
 		JSONObject obj = new JSONObject();
+		
 		try {
+			// assign the fields to the JSON object
 			obj.put("item_id", itemId);
 			obj.put("name", name);
 			obj.put("rating", rating);

--- a/src/entity/Item.java
+++ b/src/entity/Item.java
@@ -3,11 +3,15 @@ package entity;
 import java.util.Set;
 
 /**
+ * This class defines the structure of an event item holding data fields that
+ * are needed in the project
  * 
  * @author Ryan Shang
+ * @date 2020-May-07 11:37:09 AM
  *
  */
 public class Item {
+	// fields of an event item
 	private String itemId;
 	private String name;
 	private double rating;
@@ -16,5 +20,37 @@ public class Item {
 	private String imageUrl;
 	private String url;
 	private double distance;
+
+	public String getItemId() {
+		return itemId;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public double getRating() {
+		return rating;
+	}
+
+	public String getAddress() {
+		return address;
+	}
+
+	public Set<String> getCategories() {
+		return categories;
+	}
+
+	public String getImageUrl() {
+		return imageUrl;
+	}
+
+	public String getUrl() {
+		return url;
+	}
+
+	public double getDistance() {
+		return distance;
+	}
 
 }

--- a/src/entity/Item.java
+++ b/src/entity/Item.java
@@ -1,0 +1,20 @@
+package entity;
+
+import java.util.Set;
+
+/**
+ * 
+ * @author Ryan Shang
+ *
+ */
+public class Item {
+	private String itemId;
+	private String name;
+	private double rating;
+	private String address;
+	private Set<String> categories;
+	private String imageUrl;
+	private String url;
+	private double distance;
+
+}

--- a/src/entity/Item.java
+++ b/src/entity/Item.java
@@ -106,7 +106,7 @@ public class Item {
 	public JSONObject toJSONObject() {
 		// Create an empty JSON object
 		JSONObject obj = new JSONObject();
-		
+
 		try {
 			// assign the fields to the JSON object
 			obj.put("item_id", itemId);
@@ -121,6 +121,119 @@ public class Item {
 			e.printStackTrace();
 		}
 		return obj;
+	}
+
+	/**
+	 * This class is the internal builder of the Item class. It separates the
+	 * construction of the Item object from its representation so that the same
+	 * construction process can create different representations of the event item.
+	 * 
+	 * Example to instantiate Item class:
+	 * 
+	 * Item item = new ItemBuilder().setItemId().setName().set....build();
+	 * 
+	 * @author Ryan Shang
+	 * @date 2020-May-07 12:13:05 PM
+	 *
+	 */
+	public static class ItemBuilder {
+		// The same fields of Item class
+		private String itemId;
+		private String name;
+		private double rating;
+		private String address;
+		private Set<String> categories;
+		private String imageUrl;
+		private String url;
+		private double distance;
+
+		/**
+		 * This method sets up the id of the item
+		 * 
+		 * @param itemId The id of the item
+		 * @return ItemBuilder
+		 */
+		public ItemBuilder setItemId(String itemId) {
+			this.itemId = itemId;
+			return this;
+		}
+
+		/**
+		 * This method sets up the name of the item
+		 * 
+		 * @param name The name of the item
+		 * @return ItemBuilder
+		 */
+		public ItemBuilder setName(String name) {
+			this.name = name;
+			return this;
+		}
+
+		/**
+		 * This method sets up the rating of the item
+		 * 
+		 * @param rating The rating of the item
+		 * @return ItemBuilder
+		 */
+		public ItemBuilder setRating(double rating) {
+			this.rating = rating;
+			return this;
+		}
+
+		/**
+		 * This method sets up the address of the item
+		 * 
+		 * @param address The address of the item
+		 * @return ItemBuilder
+		 */
+		public ItemBuilder setAddress(String address) {
+			this.address = address;
+			return this;
+		}
+
+		/**
+		 * This method sets up the categories of the item
+		 * 
+		 * @param categories The categories of the item
+		 * @return ItemBuilder
+		 */
+		public ItemBuilder setCategories(Set<String> categories) {
+			this.categories = categories;
+			return this;
+		}
+
+		/**
+		 * This method sets up the url of the image of the item
+		 * 
+		 * @param imageUrl The url of the image of the item
+		 * @return ItemBuilder
+		 */
+		public ItemBuilder setImageUrl(String imageUrl) {
+			this.imageUrl = imageUrl;
+			return this;
+		}
+
+		/**
+		 * This method sets up the url of the item
+		 * 
+		 * @param url The url of the item
+		 * @return ItemBuilder
+		 */
+		public ItemBuilder setUrl(String url) {
+			this.url = url;
+			return this;
+		}
+
+		/**
+		 * This method sets up the distance of the item
+		 * 
+		 * @param distance The distance of the item
+		 * @return ItemBuilder
+		 */
+		public ItemBuilder setDistance(double distance) {
+			this.distance = distance;
+			return this;
+		}
 	}
 
 }

--- a/src/entity/Item.java
+++ b/src/entity/Item.java
@@ -15,7 +15,7 @@ import org.json.JSONObject;
  *
  */
 public class Item {
-	// fields of an event item
+	// private fields of an event item
 	private String itemId;
 	private String name;
 	private double rating;
@@ -24,6 +24,24 @@ public class Item {
 	private String imageUrl;
 	private String url;
 	private double distance;
+
+	/**
+	 * This private constructor uses builder pattern (ItemBuilder) to instantiate
+	 * 
+	 * @param builder An instance of ItemBuilder class
+	 * @return Item An instance of Item class
+	 */
+	private Item(ItemBuilder builder) {
+		// assign the fields from builder to item
+		this.itemId = builder.itemId;
+		this.name = builder.name;
+		this.rating = builder.rating;
+		this.address = builder.address;
+		this.categories = builder.categories;
+		this.imageUrl = builder.imageUrl;
+		this.url = builder.url;
+		this.distance = builder.distance;
+	}
 
 	/**
 	 * This method obtains the id of the event item
@@ -233,6 +251,15 @@ public class Item {
 		public ItemBuilder setDistance(double distance) {
 			this.distance = distance;
 			return this;
+		}
+
+		/**
+		 * This method builds an instance of the Item class
+		 * 
+		 * @return Item The Item class
+		 */
+		public Item build() {
+			return new Item(this);
 		}
 	}
 

--- a/src/external/GeoHash.java
+++ b/src/external/GeoHash.java
@@ -1,0 +1,71 @@
+package external;
+
+/**
+ * This class helps doing the GeoHash encoding
+ * 
+ * @author Ryan Shang
+ * @date 2020-May-07 3:35:56 PM
+ *
+ */
+public class GeoHash {
+
+	private static final String BASE_32 = "0123456789bcdefghjkmnpqrstuvwxyz";
+
+	private static int divideRangeByValue(double value, double[] range) {
+		double mid = middle(range);
+		if (value >= mid) {
+			range[0] = mid;
+			return 1;
+		} else {
+			range[1] = mid;
+			return 0;
+		}
+	}
+
+	private static double middle(double[] range) {
+		return (range[0] + range[1]) / 2;
+	}
+
+	/**
+	 * This method converts the latitude and longitude of the event to a geoPoint by
+	 * doing the hash encoding
+	 * 
+	 * @param latitude  The latitude of the event
+	 * @param longitude The longitude of the event
+	 * @param precision The precision of the search
+	 * @return String The geoPoint of the event
+	 */
+	public static String encodeGeohash(double latitude, double longitude, int precision) {
+		double[] latRange = new double[] { -90.0, 90.0 };
+		double[] lonRange = new double[] { -180.0, 180.0 };
+		boolean isEven = true;
+		int bit = 0;
+		int base32CharIndex = 0;
+		StringBuilder geohash = new StringBuilder();
+
+		while (geohash.length() < precision) {
+			if (isEven) {
+				base32CharIndex = (base32CharIndex << 1) | divideRangeByValue(longitude, lonRange);
+			} else {
+				base32CharIndex = (base32CharIndex << 1) | divideRangeByValue(latitude, latRange);
+			}
+
+			isEven = !isEven;
+
+			if (bit < 4) {
+				bit++;
+			} else {
+				geohash.append(BASE_32.charAt(base32CharIndex));
+				bit = 0;
+				base32CharIndex = 0;
+			}
+		}
+
+		return geohash.toString();
+	}
+
+	public static void main(String[] args) {
+		// Expect to see 'u4pruydqqvj8'
+		System.out.println(encodeGeohash(57.64911, 10.40744, 12));
+	}
+}

--- a/src/external/TicketMasterClient.java
+++ b/src/external/TicketMasterClient.java
@@ -128,6 +128,74 @@ public class TicketMasterClient {
 	}
 
 	/**
+	 * This helper method obtains the address of an event
+	 * 
+	 * @param event Event in JSON Object format
+	 * @return String The address of the event
+	 * @throws JSONException
+	 */
+	private String getAddress(JSONObject event) throws JSONException {
+		if (!event.isNull("_embedded")) {
+			JSONObject embedded = event.getJSONObject("_embedded");
+			if (!embedded.isNull("venues")) {
+				JSONArray venues = embedded.getJSONArray("venues");
+				for (int i = 0; i < venues.length(); ++i) {
+					JSONObject venue = venues.getJSONObject(i);
+					StringBuilder builder = new StringBuilder();
+					if (!venue.isNull("address")) {
+						JSONObject address = venue.getJSONObject("address");
+						if (!address.isNull("line1")) {
+							builder.append(address.getString("line1"));
+						}
+
+						if (!address.isNull("line2")) {
+							builder.append(",");
+							builder.append(address.getString("line2"));
+						}
+
+						if (!address.isNull("line3")) {
+							builder.append(",");
+							builder.append(address.getString("line3"));
+						}
+					}
+
+					if (!venue.isNull("city")) {
+						JSONObject city = venue.getJSONObject("city");
+						builder.append(",");
+						builder.append(city.getString("name"));
+					}
+
+					String result = builder.toString();
+					if (!result.isEmpty()) {
+						return result;
+					}
+				}
+			}
+		}
+		return "";
+	}
+	
+	/**
+	 * This helper method obtains the URL of the image of an event
+	 * 
+	 * @param event Event in JSON Object format
+	 * @return String The URL of the image of the event
+	 * @throws JSONException
+	 */
+	private String getImageUrl(JSONObject event) throws JSONException {
+		if (!event.isNull("images")) {
+			JSONArray array = event.getJSONArray("images");
+			for (int i = 0; i < array.length(); i++) {
+				JSONObject image = array.getJSONObject(i);
+				if (!image.isNull("url")) {
+					return image.getString("url");
+				}
+			}
+		}
+		return "";
+	}
+
+	/**
 	 * Main entry to test TicketMasterClient.
 	 */
 	public static void main(String[] args) {

--- a/src/external/TicketMasterClient.java
+++ b/src/external/TicketMasterClient.java
@@ -18,6 +18,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import entity.Item;
+import entity.Item.ItemBuilder;
 
 /**
  * The class connects to the TicketMaster API, sends query, and fetches event
@@ -125,6 +126,34 @@ public class TicketMasterClient {
 	private List<Item> getItemList(JSONArray events) throws JSONException {
 		// Define an empty list of Item objects
 		List<Item> itemList = new ArrayList<>();
+
+		for (int i = 0; i < events.length(); ++i) {
+			// Get the JSON object
+			JSONObject event = events.getJSONObject(i);
+			
+			// Instantiate ItemBuilder class
+			ItemBuilder builder = new ItemBuilder();
+			
+			// Set the fields of the ItemBuilder object
+			if (!event.isNull("id")) {
+				builder.setItemId(event.getString("id"));
+			}
+			if (!event.isNull("name")) {
+				builder.setName(event.getString("name"));
+			}
+			if (!event.isNull("url")) {
+				builder.setUrl(event.getString("url"));
+			}
+			if (!event.isNull("distance")) {
+				builder.setDistance(event.getDouble("distance"));
+			}
+			builder.setAddress(getAddress(event));
+			builder.setCategories(getCategories(event));
+			builder.setImageUrl(getImageUrl(event));
+			
+			// Add the successfully built item to the item list
+			itemList.add(builder.build());
+		}
 
 		return itemList;
 	}

--- a/src/external/TicketMasterClient.java
+++ b/src/external/TicketMasterClient.java
@@ -13,6 +13,13 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+/**
+ * The class connects to the TicketMaster API, sends query, and fetches event
+ * data.
+ * 
+ * @author Ryan Shang
+ * @date 2020-May-07 11:27:42 AM
+ */
 public class TicketMasterClient {
 	private static final String HOST = "https://app.ticketmaster.com";
 	private static final String ENDPOINT = "/discovery/v2/events.json";
@@ -23,9 +30,9 @@ public class TicketMasterClient {
 	 * This method search the events based on the given latitude, longitude, and
 	 * keyword. Finally it returns a JSON array of events.
 	 * 
-	 * @param lat Latitude of the event
+	 * @param lat     Latitude of the event
 	 * 
-	 * @param lon Longitude of the event
+	 * @param lon     Longitude of the event
 	 * 
 	 * @param keyword Keyword of the event
 	 * 

--- a/src/external/TicketMasterClient.java
+++ b/src/external/TicketMasterClient.java
@@ -8,10 +8,14 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import entity.Item;
 
 /**
  * The class connects to the TicketMaster API, sends query, and fetches event
@@ -105,6 +109,22 @@ public class TicketMasterClient {
 
 		return new JSONArray();
 
+	}
+
+	// Convert JSONArray to a list of item objects.
+	/**
+	 * This method converts a list of events from a JSON array to a list of Item
+	 * instances
+	 * 
+	 * @param events The list of event
+	 * @return List<Item> The list of Item objects
+	 * @throws JSONException
+	 */
+	private List<Item> getItemList(JSONArray events) throws JSONException {
+		// Define an empty list of Item objects
+		List<Item> itemList = new ArrayList<>();
+
+		return itemList;
 	}
 
 	/**

--- a/src/external/TicketMasterClient.java
+++ b/src/external/TicketMasterClient.java
@@ -57,8 +57,12 @@ public class TicketMasterClient {
 			e.printStackTrace();
 		}
 
+		// Obtain the geoHash from given lat and lon values
+		String geoHash = GeoHash.encodeGeohash(lat, lon, 8);
+
 		// Build the query for TicketMaster API
-		String query = String.format("apikey=%s&latlong=%s,%s&keyword=%s&radius=%s", API_KEY, lat, lon, keyword, 50);
+		String query = String.format("apikey=%s&geoPoint=%s&keyword=%s&radius=%s", API_KEY, geoHash, keyword, 50);
+
 		// Build the complete URL
 		String url = HOST + ENDPOINT + "?" + query;
 

--- a/src/external/TicketMasterClient.java
+++ b/src/external/TicketMasterClient.java
@@ -255,15 +255,12 @@ public class TicketMasterClient {
 	 */
 	public static void main(String[] args) {
 		TicketMasterClient client = new TicketMasterClient();
-		JSONArray events = client.search(37.38, -122.08, null);
-		try {
-			for (int i = 0; i < events.length(); ++i) {
-				JSONObject event = events.getJSONObject(i);
-				System.out.println(event.toString(2));
-			}
-		} catch (Exception e) {
-			e.printStackTrace();
+		List<Item> events = client.search(37.38, -122.08, null);
+
+		for (Item event : events) {
+			System.out.println(event.toJSONObject());
 		}
+
 	}
 
 }

--- a/src/external/TicketMasterClient.java
+++ b/src/external/TicketMasterClient.java
@@ -9,7 +9,9 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -174,7 +176,7 @@ public class TicketMasterClient {
 		}
 		return "";
 	}
-	
+
 	/**
 	 * This helper method obtains the URL of the image of an event
 	 * 
@@ -193,6 +195,30 @@ public class TicketMasterClient {
 			}
 		}
 		return "";
+	}
+
+	/**
+	 * This helper method obtains the categories of an event
+	 * 
+	 * @param event Event in JSON Object format
+	 * @return Set<String> The categories of the event
+	 * @throws JSONException
+	 */
+	private Set<String> getCategories(JSONObject event) throws JSONException {
+		Set<String> categories = new HashSet<>();
+		if (!event.isNull("classifications")) {
+			JSONArray classifications = event.getJSONArray("classifications");
+			for (int i = 0; i < classifications.length(); ++i) {
+				JSONObject classification = classifications.getJSONObject(i);
+				if (!classification.isNull("segment")) {
+					JSONObject segment = classification.getJSONObject("segment");
+					if (!segment.isNull("name")) {
+						categories.add(segment.getString("name"));
+					}
+				}
+			}
+		}
+		return categories;
 	}
 
 	/**

--- a/src/external/TicketMasterClient.java
+++ b/src/external/TicketMasterClient.java
@@ -21,7 +21,7 @@ import entity.Item;
 import entity.Item.ItemBuilder;
 
 /**
- * The class connects to the TicketMaster API, sends query, and fetches event
+ * This class connects to the TicketMaster API, sends query, and fetches event
  * data.
  * 
  * @author Ryan Shang
@@ -45,7 +45,7 @@ public class TicketMasterClient {
 	 * 
 	 * @return JSONArray The search results
 	 */
-	public JSONArray search(double lat, double lon, String keyword) {
+	public List<Item> search(double lat, double lon, String keyword) {
 		if (keyword == null) {
 			keyword = DEFAULT_KEYWORD;
 		}
@@ -78,7 +78,7 @@ public class TicketMasterClient {
 
 			// return empty JSON array when the request fails
 			if (responseCode != 200) {
-				return new JSONArray();
+				return new ArrayList<>();
 			}
 
 			// Create a BufferedReader to help read text from a character-input stream.
@@ -104,13 +104,13 @@ public class TicketMasterClient {
 			JSONObject obj = new JSONObject(responseBody.toString());
 			if (!obj.isNull("_embedded")) {
 				JSONObject embedded = obj.getJSONObject("_embedded");
-				return embedded.getJSONArray("events");
+				return getItemList(embedded.getJSONArray("events"));
 			}
 		} catch (JSONException e) {
 			e.printStackTrace();
 		}
 
-		return new JSONArray();
+		return new ArrayList<>();
 
 	}
 
@@ -130,10 +130,10 @@ public class TicketMasterClient {
 		for (int i = 0; i < events.length(); ++i) {
 			// Get the JSON object
 			JSONObject event = events.getJSONObject(i);
-			
+
 			// Instantiate ItemBuilder class
 			ItemBuilder builder = new ItemBuilder();
-			
+
 			// Set the fields of the ItemBuilder object
 			if (!event.isNull("id")) {
 				builder.setItemId(event.getString("id"));
@@ -150,7 +150,7 @@ public class TicketMasterClient {
 			builder.setAddress(getAddress(event));
 			builder.setCategories(getCategories(event));
 			builder.setImageUrl(getImageUrl(event));
-			
+
 			// Add the successfully built item to the item list
 			itemList.add(builder.build());
 		}

--- a/src/rpc/RpcHelper.java
+++ b/src/rpc/RpcHelper.java
@@ -8,13 +8,19 @@ import javax.servlet.http.HttpServletResponse;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+/**
+ * This class provides several rpc helper methods
+ * 
+ * @author Ryan Shang
+ * @date 2020-May-07 11:32:29 AM
+ */
 public class RpcHelper {
 	/**
 	 * Writes a JSON Array to HTTP response
 	 * 
 	 * @param response This is the HTTP response
 	 * 
-	 * @param array This is the JSON array to be added to HTTP response
+	 * @param array    This is the JSON array to be added to HTTP response
 	 * 
 	 * @return Nothing
 	 * 
@@ -33,7 +39,7 @@ public class RpcHelper {
 	 * 
 	 * @param response This is the HTTP response
 	 * 
-	 * @param obj This is the JSON array to be added to HTTP response
+	 * @param obj      This is the JSON array to be added to HTTP response
 	 * 
 	 * @return Nothing
 	 * 

--- a/src/rpc/SearchItem.java
+++ b/src/rpc/SearchItem.java
@@ -1,6 +1,7 @@
 package rpc;
 
 import java.io.IOException;
+import java.util.List;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -8,6 +9,9 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.json.JSONArray;
+
+import entity.Item;
 import external.TicketMasterClient;
 
 /**
@@ -37,9 +41,17 @@ public class SearchItem extends HttpServlet {
 
 		// Instantiate the TicketMasterClient class
 		TicketMasterClient client = new TicketMasterClient();
-
-		// Write the list of events to the response
-		RpcHelper.writeJsonArray(response, client.search(latitude, longitude, null));
+		
+		// Obtain the list of Item objects by client's search method
+		List<Item> items = client.search(latitude, longitude, null);
+		JSONArray array = new JSONArray();
+		
+		// Iterate the list and convert all the items to JSON objects
+		for (Item item : items) {
+			array.put(item.toJSONObject());
+		}
+		// Write the JSON list of events to response
+		RpcHelper.writeJsonArray(response, array);
 
 	}
 

--- a/src/rpc/SearchItem.java
+++ b/src/rpc/SearchItem.java
@@ -8,10 +8,6 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import external.TicketMasterClient;
 
 /**


### PR DESCRIPTION
This PR purifies the events data fetched from TicketMaster API and makes it more readable and accessible.

The original data fetched from TicketMaster API is dirty and some fields are buried deeply. This issue was solved by creating an Item class to restore all the needed fields and fill them up once the HTTP response is received.

Now the event response looks much cleaner:

![image](https://user-images.githubusercontent.com/44715573/81352209-d7d9b380-907a-11ea-8826-2f0f5f9fdff1.png)
